### PR TITLE
docs: use choice type for the semver input

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ on:
         description: "The semver to use"
         required: true
         default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
       tag:
         description: "The npm tag"
         required: false


### PR DESCRIPTION
Update the docs to use the choice type for the semver input. No changes are needed to the actual action.

Wondering if it'll be a good idea to add another choice input to publish to NPM. Mantainers may want to not publish one release to NPM without having to update the `release.yml` or remove the secret.

Closes #42