### PR TITLE
fix: ignore branch deleting errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10847,12 +10847,10 @@ module.exports = async function ({ github, context, inputs }) {
       }),
     ])
 
-    const errors = promises.filter(p => p.reason).map(p => p.reason.message)
-    if (errors.length) {
+    // Verify any errors deleting the Release. Ignore minor issues deleting the branch
+    if (promises[1].reason) {
       core.setFailed(
-        `Something went wrong while deleting the branch or release. \n Errors: ${errors.join(
-          '\n'
-        )}`
+        `Something went wrong while deleting the release. \n Errors: ${promises[1].reason.message}`
       )
     }
 

--- a/src/release.js
+++ b/src/release.js
@@ -48,12 +48,10 @@ module.exports = async function ({ github, context, inputs }) {
       }),
     ])
 
-    const errors = promises.filter(p => p.reason).map(p => p.reason.message)
-    if (errors.length) {
+    // Verify any errors deleting the Release. Ignore minor issues deleting the branch
+    if (promises[1].reason) {
       core.setFailed(
-        `Something went wrong while deleting the branch or release. \n Errors: ${errors.join(
-          '\n'
-        )}`
+        `Something went wrong while deleting the release. \n Errors: ${promises[1].reason.message}`
       )
     }
 

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -108,7 +108,7 @@ tap.test('Should delete the release if the pr is not merged', async () => {
 })
 
 tap.test(
-  'Should delete the release even if deleting the branch failed',
+  'Should delete the release even if deleting the branch failed and should not fail',
   async () => {
     const { release, stubs } = setup()
     const data = clone(DEFAULT_ACTION_DATA)
@@ -117,10 +117,7 @@ tap.test(
 
     await release(data)
 
-    sinon.assert.calledOnceWithExactly(
-      stubs.coreStub.setFailed,
-      `Something went wrong while deleting the branch or release. \n Errors: Something went wrong in the branch`
-    )
+    sinon.assert.notCalled(stubs.coreStub.setFailed)
     sinon.assert.calledOnceWithExactly(deleteReleaseStub, {
       owner: DEFAULT_ACTION_DATA.context.repo.owner,
       repo: DEFAULT_ACTION_DATA.context.repo.repo,
@@ -139,7 +136,7 @@ tap.test('Should log an error if deleting the release fails', async () => {
 
   sinon.assert.calledOnceWithExactly(
     stubs.coreStub.setFailed,
-    `Something went wrong while deleting the branch or release. \n Errors: Something went wrong in the release`
+    `Something went wrong while deleting the release. \n Errors: Something went wrong in the release`
   )
 })
 
@@ -156,7 +153,7 @@ tap.test(
 
     sinon.assert.calledOnceWithExactly(
       stubs.coreStub.setFailed,
-      `Something went wrong while deleting the branch or release. \n Errors: Something went wrong in the branch\nSomething went wrong in the release`
+      `Something went wrong while deleting the release. \n Errors: Something went wrong in the release`
     )
     sinon.assert.neverCalledWith(stubs.runSpawnStub, 'npm', [
       'publish',


### PR DESCRIPTION
Ignoring errors when deleting the release branch.

Fixes #55 . 