### PR TITLE
Skip npm publish when already done in previous failed workflow

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10880,7 +10880,7 @@ module.exports = async function ({ github, context, inputs }) {
     const npmToken = inputs['npm-token']
 
     if (npmToken) {
-      await publishToNpm({ npmToken, opticToken, opticUrl, npmTag })
+      await publishToNpm({ npmToken, opticToken, opticUrl, npmTag, version })
     } else {
       logWarning('missing npm-token')
     }
@@ -10991,9 +10991,16 @@ module.exports = transformCommitMessage
 
 "use strict";
 
+
 const { runSpawn } = __nccwpck_require__(2137)
 
-async function publishToNpm({ npmToken, opticToken, opticUrl, npmTag }) {
+async function publishToNpm({
+  npmToken,
+  opticToken,
+  opticUrl,
+  npmTag,
+  version,
+}) {
   const run = runSpawn()
 
   await run('npm', [
@@ -11002,12 +11009,25 @@ async function publishToNpm({ npmToken, opticToken, opticUrl, npmTag }) {
     `//registry.npmjs.org/:_authToken=${npmToken}`,
   ])
 
-  await run('npm', ['pack', '--dry-run'])
-  if (opticToken) {
-    const otp = await run('curl', ['-s', `${opticUrl}${opticToken}`])
-    await run('npm', ['publish', '--otp', otp, '--tag', npmTag])
-  } else {
-    await run('npm', ['publish', '--tag', npmTag])
+  // We need to check if the package was already published. This can happen if
+  // the action was already executed before, but it failed in its last step
+  // (GH release).
+  const pkgInfo = JSON.parse(await run('npm', ['view', '--json']))
+
+  // NPM only looks into the remote registry when we pass an explicit
+  // package name & version, so we don't have to fear that it reads the
+  // info from the "local" package.json file.
+  const allowNpmPublish =
+    '' === (await run('npm', ['view', `${pkgInfo.name}@${version}`]))
+
+  if (allowNpmPublish) {
+    await run('npm', ['pack', '--dry-run'])
+    if (opticToken) {
+      const otp = await run('curl', ['-s', `${opticUrl}${opticToken}`])
+      await run('npm', ['publish', '--otp', otp, '--tag', npmTag])
+    } else {
+      await run('npm', ['publish', '--tag', npmTag])
+    }
   }
 }
 

--- a/src/release.js
+++ b/src/release.js
@@ -76,7 +76,7 @@ module.exports = async function ({ github, context, inputs }) {
     const npmToken = inputs['npm-token']
 
     if (npmToken) {
-      await publishToNpm({ npmToken, opticToken, opticUrl, npmTag })
+      await publishToNpm({ npmToken, opticToken, opticUrl, npmTag, version })
     } else {
       logWarning('missing npm-token')
     }

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -1,7 +1,14 @@
 'use strict'
+
 const { runSpawn } = require('./runSpawn')
 
-async function publishToNpm({ npmToken, opticToken, opticUrl, npmTag }) {
+async function publishToNpm({
+  npmToken,
+  opticToken,
+  opticUrl,
+  npmTag,
+  version,
+}) {
   const run = runSpawn()
 
   await run('npm', [
@@ -10,12 +17,25 @@ async function publishToNpm({ npmToken, opticToken, opticUrl, npmTag }) {
     `//registry.npmjs.org/:_authToken=${npmToken}`,
   ])
 
-  await run('npm', ['pack', '--dry-run'])
-  if (opticToken) {
-    const otp = await run('curl', ['-s', `${opticUrl}${opticToken}`])
-    await run('npm', ['publish', '--otp', otp, '--tag', npmTag])
-  } else {
-    await run('npm', ['publish', '--tag', npmTag])
+  // We need to check if the package was already published. This can happen if
+  // the action was already executed before, but it failed in its last step
+  // (GH release).
+  const pkgInfo = JSON.parse(await run('npm', ['view', '--json']))
+
+  // NPM only looks into the remote registry when we pass an explicit
+  // package name & version, so we don't have to fear that it reads the
+  // info from the "local" package.json file.
+  const allowNpmPublish =
+    '' === (await run('npm', ['view', `${pkgInfo.name}@${version}`]))
+
+  if (allowNpmPublish) {
+    await run('npm', ['pack', '--dry-run'])
+    if (opticToken) {
+      const otp = await run('curl', ['-s', `${opticUrl}${opticToken}`])
+      await run('npm', ['publish', '--otp', otp, '--tag', npmTag])
+    } else {
+      await run('npm', ['publish', '--tag', npmTag])
+    }
   }
 }
 

--- a/test/publishToNpm.test.js
+++ b/test/publishToNpm.test.js
@@ -6,7 +6,18 @@ const proxyquire = require('proxyquire')
 const runSpawnAction = require('../src/utils/runSpawn')
 
 const setup = () => {
-  const runSpawnStub = sinon.stub().returns('otp123')
+  const runSpawnStub = sinon.stub()
+  runSpawnStub
+    .withArgs('curl', [
+      '-s',
+      'https://optic-test.run.app/api/generate/optic-token',
+    ])
+    .returns('otp123')
+  runSpawnStub
+    .withArgs('npm', ['view', '--json'])
+    .returns('{"name":"fakeTestPkg"}')
+  runSpawnStub.withArgs('npm', ['view', 'fakeTestPkg@v5.1.3']).returns('')
+
   const utilStub = sinon.stub(runSpawnAction, 'runSpawn').returns(runSpawnStub)
   const publishToNpmProxy = proxyquire('../src/utils/publishToNpm', {
     './runSpawn': utilStub,
@@ -26,6 +37,7 @@ tap.test('Should publish to npm with optic', async t => {
     opticToken: 'optic-token',
     opticUrl: 'https://optic-test.run.app/api/generate/',
     npmTag: 'latest',
+    version: 'v5.1.3',
   })
 
   sinon.assert.calledWithExactly(runSpawnStub.getCall(0), 'npm', [
@@ -35,19 +47,22 @@ tap.test('Should publish to npm with optic', async t => {
   ])
   t.pass('npm config')
 
-  sinon.assert.calledWithExactly(runSpawnStub.getCall(1), 'npm', [
+  // We skip calls in these checks:
+  // - 1 used to get the package name
+  // - 2 used to check if the package version is already published
+  sinon.assert.calledWithExactly(runSpawnStub.getCall(3), 'npm', [
     'pack',
     '--dry-run',
   ])
   t.pass('npm pack called')
 
-  sinon.assert.calledWithExactly(runSpawnStub.getCall(2), 'curl', [
+  sinon.assert.calledWithExactly(runSpawnStub.getCall(4), 'curl', [
     '-s',
     'https://optic-test.run.app/api/generate/optic-token',
   ])
   t.pass('curl called')
 
-  sinon.assert.calledWithExactly(runSpawnStub.getCall(3), 'npm', [
+  sinon.assert.calledWithExactly(runSpawnStub.getCall(5), 'npm', [
     'publish',
     '--otp',
     'otp123',
@@ -63,6 +78,7 @@ tap.test('Should publish to npm without optic', async () => {
     npmToken: 'a-token',
     opticUrl: 'https://optic-test.run.app/api/generate/',
     npmTag: 'latest',
+    version: 'v5.1.3',
   })
 
   sinon.assert.calledWithExactly(runSpawnStub, 'npm', ['pack', '--dry-run'])
@@ -71,4 +87,71 @@ tap.test('Should publish to npm without optic', async () => {
     '--tag',
     'latest',
   ])
+})
+
+tap.test(
+  'Should skip npm package publication when it was already published',
+  async () => {
+    const { publishToNpmProxy, runSpawnStub } = setup()
+
+    runSpawnStub
+      .withArgs('npm', ['view', 'fakeTestPkg@v5.1.3'])
+      .returns('fake package data that says it was published')
+
+    await publishToNpmProxy.publishToNpm({
+      npmToken: 'a-token',
+      opticUrl: 'https://optic-test.run.app/api/generate/',
+      npmTag: 'latest',
+      version: 'v5.1.3',
+    })
+
+    sinon.assert.neverCalledWith(runSpawnStub, 'npm', [
+      'publish',
+      '--otp',
+      'otp123',
+      '--tag',
+      'latest',
+    ])
+    sinon.assert.neverCalledWith(runSpawnStub, 'npm', [
+      'publish',
+      '--tag',
+      'latest',
+    ])
+  }
+)
+
+tap.test('Should stop action if package info retrieval fails', async t => {
+  t.plan(3)
+  const { publishToNpmProxy, runSpawnStub } = setup()
+
+  runSpawnStub
+    .withArgs('npm', ['view', 'fakeTestPkg@v5.1.3'])
+    .throws(new Error('Network Error'))
+
+  try {
+    await publishToNpmProxy.publishToNpm({
+      npmToken: 'a-token',
+      opticUrl: 'https://optic-test.run.app/api/generate/',
+      npmTag: 'latest',
+      version: 'v5.1.3',
+    })
+  } catch (e) {
+    t.equal(e.message, 'Network Error')
+  }
+
+  sinon.assert.neverCalledWith(runSpawnStub, 'npm', [
+    'publish',
+    '--otp',
+    'otp123',
+    '--tag',
+    'latest',
+  ])
+  t.pass('package is not published with otp code')
+
+  sinon.assert.neverCalledWith(runSpawnStub, 'npm', [
+    'publish',
+    '--tag',
+    'latest',
+  ])
+  t.pass('package is not published without otp code')
 })

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -58,7 +58,15 @@ function setup() {
   const coreStub = sinon.stub(core)
   deleteReleaseStub.resetHistory()
   deleteReleaseStub.resolves()
-  const runSpawnStub = sinon.stub().returns('otp123')
+
+  const runSpawnStub = sinon.stub()
+  runSpawnStub
+    .withArgs('curl', [
+      '-s',
+      'https://optic-test.run.app/api/generate/optic-token',
+    ])
+    .returns('otp123')
+
   const runSpawnProxy = sinon
     .stub(runSpawnAction, 'runSpawn')
     .returns(runSpawnStub)
@@ -159,11 +167,7 @@ tap.test(
       stubs.coreStub.setFailed,
       `Something went wrong while deleting the release. \n Errors: Something went wrong in the release`
     )
-    sinon.assert.neverCalledWith(stubs.runSpawnStub, 'npm', [
-      'publish',
-      '--tag',
-      'latest',
-    ])
+    sinon.assert.notCalled(stubs.publishToNpmStub)
   }
 )
 
@@ -195,18 +199,7 @@ tap.test('Should not publish to npm if there is no npm token', async () => {
     },
   })
 
-  sinon.assert.neverCalledWith(stubs.runSpawnStub, 'npm', [
-    'publish',
-    '--tag',
-    'latest',
-  ])
-  sinon.assert.neverCalledWith(stubs.runSpawnStub, 'npm', [
-    'publish',
-    '--otp',
-    'otp123',
-    '--tag',
-    'latest',
-  ])
+  sinon.assert.notCalled(stubs.publishToNpmStub)
 })
 
 tap.test('Should publish to npm with optic', async () => {
@@ -298,11 +291,7 @@ tap.test("Should NOT use npm if the pr wasn't merged", async () => {
     'sync-semver-tags': 'true',
   }
   await release(data)
-  sinon.assert.neverCalledWith(stubs.runSpawnStub, 'npm', [
-    'publish',
-    '--tag',
-    'latest',
-  ])
+  sinon.assert.notCalled(stubs.publishToNpmStub)
 })
 
 tap.test("Should NOT tag version in git if the pr wasn't merged", async () => {


### PR DESCRIPTION
### Main changes
It skips NPM package publication if the package was already published in a previously failed workflow execution. This can happen if the NPM publication is successful, but the Github release fails afterwards.

This change allows us to re-run this workflow again without having to bump versions, so we can fix the "inconsistency" between GH releases and NPM packages' versions.

### Minor changes
The last PR merge introduced some "regressions" in some tests: some assertions validated that some commands were never triggered, but after having extracted the `publishToNpm` function that was never going to happen in these tests, because these steps were abstracted away into another function that was being stubbed. I replaced these assertions by a "stronger" one, related to the newly introduced function.

### Notes
In the future, this might need refactoring: to reorder some steps (in case any of them are idempotent), to simplify the code (i.e.: we could avoid having to perform some checks, and remove some if-else blocks).

Fixes #86