### PR TITLE
update optic link in the issue comment

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,4 +1,4 @@
-statements: 80
-lines: 80
-functions: 75
-branches: 80
+statements: 90
+lines: 90
+functions: 78
+branches: 90

--- a/dist/index.js
+++ b/dist/index.js
@@ -20134,12 +20134,12 @@ function createCommentBody(
 ) {
   const npmUrl = `https://www.npmjs.com/package/${packageName}/v/${packageVersion}`
 
-  if (shouldPostNpmLink || true) {
-    return `🎉 This issue has been resolved in version ${packageVersion} 🎉 
+  if (shouldPostNpmLink) {
+    return `🎉 This issue has been resolved in version ${packageVersion} 🎉
 
 
   The release is available on:
-  * [npm package](${npmUrl}) 
+  * [npm package](${npmUrl})
   * [GitHub release](${releaseUrl})
 
 
@@ -20150,8 +20150,8 @@ function createCommentBody(
 
 
   The release is available on:
-  * [GitHub release](${releaseUrl}) 
-  
+  * [GitHub release](${releaseUrl})
+
 
   Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -20143,7 +20143,7 @@ async function notifyIssues(githubClient, owner, repo, release) {
 
   const body = `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
   The release is available on: \n * [npm package](${npmUrl}) \n
-  * [GitHub release](${releaseUrl}) \n\n Your **[optic](https://github.com/nearform/optic)** bot 📦🚀`
+  * [GitHub release](${releaseUrl}) \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 
   await pMap(
     issueNumbersToNotify,

--- a/dist/index.js
+++ b/dist/index.js
@@ -20134,16 +20134,26 @@ function createCommentBody(
 ) {
   const npmUrl = `https://www.npmjs.com/package/${packageName}/v/${packageVersion}`
 
-  if (shouldPostNpmLink) {
-    return `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
-  The release is available on: \n * [npm package](${npmUrl}) 
-  \n * [GitHub release](${releaseUrl}) 
-  \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+  if (shouldPostNpmLink || true) {
+    return `🎉 This issue has been resolved in version ${packageVersion} 🎉 
+
+
+  The release is available on:
+  * [npm package](${npmUrl}) 
+  * [GitHub release](${releaseUrl})
+
+
+  Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
   }
 
-  return `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
-  The release is available on: \n * [GitHub release](${releaseUrl}) 
-  \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+  return `🎉 This issue has been resolved in version ${packageVersion} 🎉
+
+
+  The release is available on:
+  * [GitHub release](${releaseUrl}) 
+  
+
+  Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 }
 
 async function notifyIssues(

--- a/src/release.js
+++ b/src/release.js
@@ -75,10 +75,10 @@ module.exports = async function ({ github, context, inputs }) {
 
   const shouldRevertCommit = /true/i.test(inputs['revert-commit-after-failure'])
 
-  try {
-    const opticToken = inputs['optic-token']
-    const npmToken = inputs['npm-token']
+  const opticToken = inputs['optic-token']
+  const npmToken = inputs['npm-token']
 
+  try {
     if (npmToken) {
       await publishToNpm({ npmToken, opticToken, opticUrl, npmTag, version })
     } else {
@@ -129,7 +129,7 @@ module.exports = async function ({ github, context, inputs }) {
       try {
         // post a comment about release on npm to any linked issues in the
         // any of the PRs in this release
-        await notifyIssues(github, owner, repo, release)
+        await notifyIssues(github, npmToken, owner, repo, release)
       } catch (err) {
         logWarning('Failed to notify any/all issues')
         logError(err)

--- a/src/release.js
+++ b/src/release.js
@@ -75,10 +75,10 @@ module.exports = async function ({ github, context, inputs }) {
 
   const shouldRevertCommit = /true/i.test(inputs['revert-commit-after-failure'])
 
-  const opticToken = inputs['optic-token']
-  const npmToken = inputs['npm-token']
-
   try {
+    const opticToken = inputs['optic-token']
+    const npmToken = inputs['npm-token']
+
     if (npmToken) {
       await publishToNpm({ npmToken, opticToken, opticUrl, npmTag, version })
     } else {
@@ -129,7 +129,9 @@ module.exports = async function ({ github, context, inputs }) {
       try {
         // post a comment about release on npm to any linked issues in the
         // any of the PRs in this release
-        await notifyIssues(github, npmToken, owner, repo, release)
+        const shouldPostNpmLink = Boolean(inputs['npm-token'])
+
+        await notifyIssues(github, shouldPostNpmLink, owner, repo, release)
       } catch (err) {
         logWarning('Failed to notify any/all issues')
         logError(err)

--- a/src/utils/notifyIssues.js
+++ b/src/utils/notifyIssues.js
@@ -58,7 +58,7 @@ async function notifyIssues(githubClient, owner, repo, release) {
 
   const body = `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
   The release is available on: \n * [npm package](${npmUrl}) \n
-  * [GitHub release](${releaseUrl}) \n\n Your **[optic](https://github.com/nearform/optic)** bot 📦🚀`
+  * [GitHub release](${releaseUrl}) \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 
   await pMap(
     issueNumbersToNotify,

--- a/src/utils/notifyIssues.js
+++ b/src/utils/notifyIssues.js
@@ -39,7 +39,22 @@ async function getLinkedIssueNumbers(github, prNumber, repoOwner, repoName) {
   return linkedIssues.map(issue => issue.number)
 }
 
-async function notifyIssues(githubClient, owner, repo, release) {
+function createCommentBody(npmToken, packageName, packageVersion, releaseUrl) {
+  const npmUrl = `https://www.npmjs.com/package/${packageName}/v/${packageVersion}`
+
+  if (npmToken) {
+    return `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
+  The release is available on: \n * [npm package](${npmUrl}) 
+  \n * [GitHub release](${releaseUrl}) 
+  \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+  }
+
+  return `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
+  The release is available on: \n * [GitHub release](${releaseUrl}) 
+  \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+}
+
+async function notifyIssues(githubClient, npmToken, owner, repo, release) {
   const packageJsonFile = fs.readFileSync('./package.json', 'utf8')
   const packageJson = JSON.parse(packageJsonFile)
 
@@ -54,11 +69,12 @@ async function notifyIssues(githubClient, owner, repo, release) {
     )
   ).flat()
 
-  const npmUrl = `https://www.npmjs.com/package/${packageName}/v/${packageVersion}`
-
-  const body = `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
-  The release is available on: \n * [npm package](${npmUrl}) \n
-  * [GitHub release](${releaseUrl}) \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+  const body = createCommentBody(
+    npmToken,
+    packageName,
+    packageVersion,
+    releaseUrl
+  )
 
   await pMap(
     issueNumbersToNotify,

--- a/src/utils/notifyIssues.js
+++ b/src/utils/notifyIssues.js
@@ -47,12 +47,12 @@ function createCommentBody(
 ) {
   const npmUrl = `https://www.npmjs.com/package/${packageName}/v/${packageVersion}`
 
-  if (shouldPostNpmLink || true) {
-    return `🎉 This issue has been resolved in version ${packageVersion} 🎉 
+  if (shouldPostNpmLink) {
+    return `🎉 This issue has been resolved in version ${packageVersion} 🎉
 
 
   The release is available on:
-  * [npm package](${npmUrl}) 
+  * [npm package](${npmUrl})
   * [GitHub release](${releaseUrl})
 
 
@@ -63,8 +63,8 @@ function createCommentBody(
 
 
   The release is available on:
-  * [GitHub release](${releaseUrl}) 
-  
+  * [GitHub release](${releaseUrl})
+
 
   Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 }

--- a/src/utils/notifyIssues.js
+++ b/src/utils/notifyIssues.js
@@ -47,16 +47,26 @@ function createCommentBody(
 ) {
   const npmUrl = `https://www.npmjs.com/package/${packageName}/v/${packageVersion}`
 
-  if (shouldPostNpmLink) {
-    return `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
-  The release is available on: \n * [npm package](${npmUrl}) 
-  \n * [GitHub release](${releaseUrl}) 
-  \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+  if (shouldPostNpmLink || true) {
+    return `🎉 This issue has been resolved in version ${packageVersion} 🎉 
+
+
+  The release is available on:
+  * [npm package](${npmUrl}) 
+  * [GitHub release](${releaseUrl})
+
+
+  Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
   }
 
-  return `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
-  The release is available on: \n * [GitHub release](${releaseUrl}) 
-  \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+  return `🎉 This issue has been resolved in version ${packageVersion} 🎉
+
+
+  The release is available on:
+  * [GitHub release](${releaseUrl}) 
+  
+
+  Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 }
 
 async function notifyIssues(

--- a/src/utils/notifyIssues.js
+++ b/src/utils/notifyIssues.js
@@ -39,10 +39,15 @@ async function getLinkedIssueNumbers(github, prNumber, repoOwner, repoName) {
   return linkedIssues.map(issue => issue.number)
 }
 
-function createCommentBody(npmToken, packageName, packageVersion, releaseUrl) {
+function createCommentBody(
+  shouldPostNpmLink,
+  packageName,
+  packageVersion,
+  releaseUrl
+) {
   const npmUrl = `https://www.npmjs.com/package/${packageName}/v/${packageVersion}`
 
-  if (npmToken) {
+  if (shouldPostNpmLink) {
     return `🎉 This issue has been resolved in version ${packageVersion} 🎉 \n\n
   The release is available on: \n * [npm package](${npmUrl}) 
   \n * [GitHub release](${releaseUrl}) 
@@ -54,7 +59,13 @@ function createCommentBody(npmToken, packageName, packageVersion, releaseUrl) {
   \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 }
 
-async function notifyIssues(githubClient, npmToken, owner, repo, release) {
+async function notifyIssues(
+  githubClient,
+  shouldPostNpmLink,
+  owner,
+  repo,
+  release
+) {
   const packageJsonFile = fs.readFileSync('./package.json', 'utf8')
   const packageJson = JSON.parse(packageJsonFile)
 
@@ -70,7 +81,7 @@ async function notifyIssues(githubClient, npmToken, owner, repo, release) {
   ).flat()
 
   const body = createCommentBody(
-    npmToken,
+    shouldPostNpmLink,
     packageName,
     packageVersion,
     releaseUrl

--- a/test/notifyIssues.test.js
+++ b/test/notifyIssues.test.js
@@ -93,7 +93,7 @@ tap.test(
 
     const expectedCommentBody = `🎉 This issue has been resolved in version 1.0.0 🎉 \n\n
   The release is available on: \n * [npm package](https://www.npmjs.com/package/packageName/v/1.0.0) \n
-  * [GitHub release](some_url) \n\n Your **[optic](https://github.com/nearform/optic)** bot 📦🚀`
+  * [GitHub release](some_url) \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 
     sinon.assert.calledWith(createCommentStub, {
       owner: 'owner',

--- a/test/notifyIssues.test.js
+++ b/test/notifyIssues.test.js
@@ -54,7 +54,7 @@ tap.test('Should not call createComment if no linked issues', async () => {
 
   const release = { body: releaseNotes, html_url: 'some_url' }
 
-  await notifyIssues(DEFAULT_GITHUB_CLIENT, undefined, 'owner', 'repo', release)
+  await notifyIssues(DEFAULT_GITHUB_CLIENT, false, 'owner', 'repo', release)
 
   sinon.assert.notCalled(createCommentStub)
 })
@@ -86,7 +86,7 @@ tap.test(
 
     await notifyIssues(
       { ...DEFAULT_GITHUB_CLIENT, graphql: graphqlStub },
-      'npm-token',
+      true,
       'owner',
       'repo',
       release
@@ -140,7 +140,7 @@ tap.test(
 
     await notifyIssues(
       { ...DEFAULT_GITHUB_CLIENT, graphql: graphqlStub },
-      undefined,
+      false,
       'owner',
       'repo',
       release

--- a/test/notifyIssues.test.js
+++ b/test/notifyIssues.test.js
@@ -92,10 +92,15 @@ tap.test(
       release
     )
 
-    const expectedCommentBody = `🎉 This issue has been resolved in version 1.0.0 🎉 \n\n
-  The release is available on: \n * [npm package](https://www.npmjs.com/package/packageName/v/1.0.0) 
-  \n * [GitHub release](some_url) 
-  \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+    const expectedCommentBody = `🎉 This issue has been resolved in version 1.0.0 🎉
+
+
+  The release is available on:
+  * [npm package](https://www.npmjs.com/package/packageName/v/1.0.0)
+  * [GitHub release](some_url)
+
+
+  Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 
     sinon.assert.calledWith(createCommentStub, {
       owner: 'owner',
@@ -146,9 +151,14 @@ tap.test(
       release
     )
 
-    const expectedCommentBody = `🎉 This issue has been resolved in version 1.0.0 🎉 \n\n
-  The release is available on: \n * [GitHub release](some_url) 
-  \n\n Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
+    const expectedCommentBody = `🎉 This issue has been resolved in version 1.0.0 🎉
+
+
+  The release is available on:
+  * [GitHub release](some_url)
+
+
+  Your **[optic](https://github.com/nearform/optic-release-automation-action)** bot 📦🚀`
 
     sinon.assert.calledWith(createCommentStub, {
       owner: 'owner',

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -527,7 +527,7 @@ tap.test(
     sinon.assert.calledWith(
       stubs.notifyIssuesStub,
       DEFAULT_ACTION_DATA.github,
-      'a-token',
+      true,
       'test',
       'repo',
       { body: 'test_body', html_url: 'test_url' }

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -527,6 +527,7 @@ tap.test(
     sinon.assert.calledWith(
       stubs.notifyIssuesStub,
       DEFAULT_ACTION_DATA.github,
+      'a-token',
       'test',
       'repo',
       { body: 'test_body', html_url: 'test_url' }


### PR DESCRIPTION
Resolve #128 

- Replaced the URL for the `optic` bot to  point to https://github.com/nearform/optic-release-automation-action
- If the `npm-token` is missing from the inputs, then do not include the NPM package link in the comment placed on the issue