### PR TITLE
fix: support behavior of recent npm view

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26795,12 +26795,19 @@ async function allowNpmPublish(version) {
   // NPM only looks into the remote registry when we pass an explicit
   // package name & version, so we don't have to fear that it reads the
   // info from the "local" package.json file.
-  const packageVersionInfo = await run('npm', [
-    'view',
-    `${packageName}@${version}`,
-  ])
+  let packageVersionInfo
 
-  return packageVersionInfo === ''
+  try {
+    // npm < v8.13.0 returns empty output, newer versions throw a E404
+    // We handle both and consider them as package version not existing
+    packageVersionInfo = await run('npm', ['view', `${packageName}@${version}`])
+  } catch (error) {
+    if (!error?.message?.match(/code E404/)) {
+      throw error
+    }
+  }
+
+  return !packageVersionInfo
 }
 
 async function publishToNpm({


### PR DESCRIPTION
Version 8.13.0 of npm changed the behavior of the view/show command to throw an error when a specific version of a package is not found. The previous behavior would exit the process with exit code 0 without printing anything to the stdout.

Since we can't assume which version of Node is running in the workflow, we support both.

https://github.com/npm/cli/blob/latest/CHANGELOG.md#v8130-2022-06-22

Fixes #148 