### PR TITLE
chore: replace set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         npm version --no-git-tag-version ${{ inputs.semver }}
-        echo "::set-output name=PACKAGE_VERSION::$(echo $(node -p "require('./package.json').version"))"
+        echo "PACKAGE_VERSION=$(echo $(node -p "require('./package.json').version"))" >> $GITHUB_OUTPUT
       shell: 'bash'
 
     - name: Build the package


### PR DESCRIPTION
GitHub Actions: Deprecating save-state and set-output commands.

GitHub actions using the mentioned commands will start to fail from 1st of June of 2023.
[Reference](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)