### PR TITLE
Change max PR body size

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27619,7 +27619,7 @@ const _truncate = __nccwpck_require__(4436)
 
 const md = __nccwpck_require__(8561)()
 
-const PR_BODY_TRUNCATE_SIZE = 60000
+const PR_BODY_TRUNCATE_SIZE = 30000
 
 function getPrNumbersFromReleaseNotes(releaseNotes) {
   const parsedReleaseNotes = md.parse(releaseNotes, {})

--- a/src/utils/releaseNotes.js
+++ b/src/utils/releaseNotes.js
@@ -5,7 +5,7 @@ const _truncate = require('lodash.truncate')
 
 const md = require('markdown-it')()
 
-const PR_BODY_TRUNCATE_SIZE = 60000
+const PR_BODY_TRUNCATE_SIZE = 30000
 
 function getPrNumbersFromReleaseNotes(releaseNotes) {
   const parsedReleaseNotes = md.parse(releaseNotes, {})


### PR DESCRIPTION
It seems the 60000 characters limit we had for release notes is not working as expected. The GitHub API is throwing an error with the message `Server error` and status code`502` if the limit is more than 30000.

Note: I found this limit by trial and error and did not find any documentation regarding this problem.

Closes #224 