### PR TITLE
Remove release notes related to optic release

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27773,7 +27773,8 @@ async function generateReleaseNotes(token, newVersion, baseVersion) {
 
     logInfo(`Release notes generated: [${baseVersion} -> ${newVersion}]`)
 
-    return excludeUnwantedReleaseNotes(releaseNotes)
+    const filteredReleaseNotes = excludeUnwantedReleaseNotes(releaseNotes)
+    return filteredReleaseNotes
   } catch (err) {
     throw new Error(
       `An error occurred while generating the release notes: ${err.message}`

--- a/dist/index.js
+++ b/dist/index.js
@@ -27711,7 +27711,9 @@ module.exports = {
 
 
 const github = __nccwpck_require__(5438)
-const { logInfo } = __nccwpck_require__(653)
+const { logInfo, logWarning } = __nccwpck_require__(653)
+
+const opticLabelText = '* [OPTIC-RELEASE-AUTOMATION]'
 
 async function fetchLatestRelease(token) {
   try {
@@ -27741,6 +27743,19 @@ async function fetchLatestRelease(token) {
   }
 }
 
+function excludeUnwantedReleaseNotes(releaseNotes = '') {
+  try {
+    const splitLines = releaseNotes.split('\n')
+
+    return splitLines.filter(line => !line.includes(opticLabelText)).join('\n')
+  } catch (error) {
+    logWarning(
+      `Error excluding unwanted release notes. Error - ${error.message}`
+    )
+  }
+  return releaseNotes
+}
+
 async function generateReleaseNotes(token, newVersion, baseVersion) {
   try {
     logInfo(`Generating release notes: [${baseVersion} -> ${newVersion}]`)
@@ -27758,7 +27773,7 @@ async function generateReleaseNotes(token, newVersion, baseVersion) {
 
     logInfo(`Release notes generated: [${baseVersion} -> ${newVersion}]`)
 
-    return releaseNotes
+    return excludeUnwantedReleaseNotes(releaseNotes)
   } catch (err) {
     throw new Error(
       `An error occurred while generating the release notes: ${err.message}`

--- a/src/utils/releases.js
+++ b/src/utils/releases.js
@@ -63,7 +63,8 @@ async function generateReleaseNotes(token, newVersion, baseVersion) {
 
     logInfo(`Release notes generated: [${baseVersion} -> ${newVersion}]`)
 
-    return excludeUnwantedReleaseNotes(releaseNotes)
+    const filteredReleaseNotes = excludeUnwantedReleaseNotes(releaseNotes)
+    return filteredReleaseNotes
   } catch (err) {
     throw new Error(
       `An error occurred while generating the release notes: ${err.message}`

--- a/src/utils/releases.js
+++ b/src/utils/releases.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const github = require('@actions/github')
-const { logInfo } = require('../log')
+const { logInfo, logWarning } = require('../log')
+
+const opticLabelText = '* [OPTIC-RELEASE-AUTOMATION]'
 
 async function fetchLatestRelease(token) {
   try {
@@ -31,6 +33,19 @@ async function fetchLatestRelease(token) {
   }
 }
 
+function excludeUnwantedReleaseNotes(releaseNotes = '') {
+  try {
+    const splitLines = releaseNotes.split('\n')
+
+    return splitLines.filter(line => !line.includes(opticLabelText)).join('\n')
+  } catch (error) {
+    logWarning(
+      `Error excluding unwanted release notes. Error - ${error.message}`
+    )
+  }
+  return releaseNotes
+}
+
 async function generateReleaseNotes(token, newVersion, baseVersion) {
   try {
     logInfo(`Generating release notes: [${baseVersion} -> ${newVersion}]`)
@@ -48,7 +63,7 @@ async function generateReleaseNotes(token, newVersion, baseVersion) {
 
     logInfo(`Release notes generated: [${baseVersion} -> ${newVersion}]`)
 
-    return releaseNotes
+    return excludeUnwantedReleaseNotes(releaseNotes)
   } catch (err) {
     throw new Error(
       `An error occurred while generating the release notes: ${err.message}`

--- a/test/releases.test.js
+++ b/test/releases.test.js
@@ -114,3 +114,73 @@ tap.test(
     await t.resolves(releasesModule.fetchLatestRelease(TOKEN))
   }
 )
+
+tap.test(
+  'generateReleaseNotes returns release notes excluding the Optic PR',
+  async t => {
+    const testReleaseNotes = `
+    ## Whats Changed\n +
+    * [OPTIC-RELEASE-AUTOMATION] release/v1.2.4 by @optic-release-automation in https://github.com/nearform/github-board-slack-notifications/pull/139
+    * chore 15 by @people in https://github.com/owner/repo/pull/13\n
+    * chore 18 by @people in https://github.com/owner/repo/pull/15\n
+    * chore 19 by @people in https://github.com/owner/repo/pull/16\n
+    * chore 21 by @people in https://github.com/owner/repo/pull/18\n
+    * fix 26 by @people in https://github.com/owner/repo/pull/42\n
+    * feature 30 by @people in https://github.com/owner/repo/pull/50\n
+    * fix 27 by @people in https://github.com/owner/repo/pull/52\n
+    * fix 32 by @people in https://github.com/owner/repo/pull/53\n
+    \n
+    \n
+    ## New Contributors\n
+    * @people made their first contribution in https://github.com/owner/repo/pull/13\n
+    * @people made their first contribution in https://github.com/owner/repo/pull/16\n
+    * @people made their first contribution in https://github.com/owner/repo/pull/42\n
+    * @people made their first contribution in https://github.com/owner/repo/pull/53\n
+    \n
+    \n
+    ## New documentation\n
+    * Link: https://somewhere.com/on/the/internet
+    \n
+    \n
+    **Full Changelog**: https://github.com/owner/repo/compare/v1.0.20...v1.1.0
+`
+
+    const logStub = sinon.stub(actionLog)
+    const releasesModule = tap.mock('../src/utils/releases.js', {
+      '../src/log.js': logStub,
+      '@actions/github': {
+        context: {
+          repo: {
+            repo: 'repo',
+            owner: 'owner',
+          },
+        },
+        getOctokit: () => ({
+          rest: {
+            repos: {
+              getLatestRelease: async () => {
+                return {
+                  status: 200,
+                  data: {},
+                }
+              },
+              generateReleaseNotes: async () => {
+                return {
+                  status: 200,
+                  data: testReleaseNotes,
+                }
+              },
+            },
+          },
+        }),
+      },
+    })
+
+    const releaseNotes = await releasesModule.generateReleaseNotes(
+      TOKEN,
+      '1.1.0',
+      '1.0.0'
+    )
+    t.notOk(releaseNotes.includes('[OPTIC-RELEASE-AUTOMATION]'))
+  }
+)


### PR DESCRIPTION
This PR removes the notes generated by the optic release automation from the changelog.

Closes #219 