### PR TITLE
Fix: Git error when trying to commit

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79796,24 +79796,22 @@ async function execWithOutput(cmd, args, { cwd } = {}) {
   const stderrDecoder = new StringDecoder('utf8')
 
   const options = {
-    silent: true, // don't print exec output to stdout
+    silent: false, // don't print exec output to stdout
   }
 
   /* istanbul ignore else */
-  if (cwd !== '') {
+  if (cwd) {
     options.cwd = cwd
   }
 
   options.listeners = {
     /**
-     *
      * @param {Buffer} data
      */
     stdout: data => {
       output += stdoutDecoder.write(data)
     },
     /**
-     *
      * @param {Buffer} data
      */
     stderr: data => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79368,6 +79368,7 @@ module.exports = async function ({ context, inputs, packageVersion }) {
   await execWithOutput('git', ['add', '-A'])
   await execWithOutput('git', [
     'commit',
+    '--no-verify',
     '-m',
     `"${transformCommitMessage(messageTemplate, newVersion)}"`,
   ])

--- a/dist/index.js
+++ b/dist/index.js
@@ -79797,22 +79797,24 @@ async function execWithOutput(cmd, args, { cwd } = {}) {
   const stderrDecoder = new StringDecoder('utf8')
 
   const options = {
-    silent: false, // don't print exec output to stdout
+    silent: true, // don't print exec output to stdout
   }
 
   /* istanbul ignore else */
-  if (cwd) {
+  if (cwd !== '') {
     options.cwd = cwd
   }
 
   options.listeners = {
     /**
+     *
      * @param {Buffer} data
      */
     stdout: data => {
       output += stdoutDecoder.write(data)
     },
     /**
+     *
      * @param {Buffer} data
      */
     stderr: data => {

--- a/src/openPr.js
+++ b/src/openPr.js
@@ -99,6 +99,7 @@ module.exports = async function ({ context, inputs, packageVersion }) {
   await execWithOutput('git', ['add', '-A'])
   await execWithOutput('git', [
     'commit',
+    '--no-verify',
     '-m',
     `"${transformCommitMessage(messageTemplate, newVersion)}"`,
   ])

--- a/src/utils/execWithOutput.js
+++ b/src/utils/execWithOutput.js
@@ -19,22 +19,24 @@ async function execWithOutput(cmd, args, { cwd } = {}) {
   const stderrDecoder = new StringDecoder('utf8')
 
   const options = {
-    silent: false, // don't print exec output to stdout
+    silent: true, // don't print exec output to stdout
   }
 
   /* istanbul ignore else */
-  if (cwd) {
+  if (cwd !== '') {
     options.cwd = cwd
   }
 
   options.listeners = {
     /**
+     *
      * @param {Buffer} data
      */
     stdout: data => {
       output += stdoutDecoder.write(data)
     },
     /**
+     *
      * @param {Buffer} data
      */
     stderr: data => {

--- a/src/utils/execWithOutput.js
+++ b/src/utils/execWithOutput.js
@@ -19,24 +19,22 @@ async function execWithOutput(cmd, args, { cwd } = {}) {
   const stderrDecoder = new StringDecoder('utf8')
 
   const options = {
-    silent: true, // don't print exec output to stdout
+    silent: false, // don't print exec output to stdout
   }
 
   /* istanbul ignore else */
-  if (cwd !== '') {
+  if (cwd) {
     options.cwd = cwd
   }
 
   options.listeners = {
     /**
-     *
      * @param {Buffer} data
      */
     stdout: data => {
       output += stdoutDecoder.write(data)
     },
     /**
-     *
      * @param {Buffer} data
      */
     stderr: data => {

--- a/test/bump.test.js
+++ b/test/bump.test.js
@@ -129,6 +129,7 @@ tap.test('should create a new git branch', async () => {
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', ['add', '-A'])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'commit',
+    '--no-verify',
     '-m',
     `"Release v${TEST_VERSION}"`,
   ])
@@ -155,6 +156,7 @@ tap.test('should handle custom commit messages', async () => {
   ])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'commit',
+    '--no-verify',
     '-m',
     `"[v${TEST_VERSION}] The brand new v${TEST_VERSION} has been released"`,
   ])
@@ -189,6 +191,7 @@ tap.test('should work with a custom version-prefix', async () => {
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', ['add', '-A'])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'commit',
+    '--no-verify',
     '-m',
     `"Release v${TEST_VERSION}"`,
   ])


### PR DESCRIPTION
This resolves the issue `The process '/usr/bin/git' failed with exit code 1` which was happening when the action was trying to do a `git commit` operation.

Problem was caused by [commitlint](https://github.com/conventional-changelog/commitlint#what-is-commitlint). Fixed by ignoring the hook when making the commit.

closes #243 