### PR TITLE
Fix failing npm after git spawn change

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -80008,6 +80008,7 @@ async function allowNpmPublish(version) {
     const packageInfo = await execWithOutput('npm', ['view', '--json'])
     packageName = packageInfo ? JSON.parse(packageInfo).name : null
   } catch (error) {
+    console.log(error)
     if (!error?.message?.match(/code E404/)) {
       throw error
     }
@@ -80031,6 +80032,7 @@ async function allowNpmPublish(version) {
       `${packageName}@${version}`,
     ])
   } catch (error) {
+    console.log(error)
     if (!error?.message?.match(/code E404/)) {
       throw error
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -79822,7 +79822,13 @@ async function execWithOutput(cmd, args, { cwd } = {}) {
     },
   }
 
-  const code = await exec(cmd, args, options)
+  let code = 0
+  try {
+    code = await exec(cmd, args, options)
+  } catch {
+    //the actual error does not matter, because it does not contain any relevant information. The actual exec output is collected bellow in output and errorOutput
+    code = 1
+  }
 
   output += stdoutDecoder.end()
   errorOutput += stderrDecoder.end()
@@ -80008,7 +80014,6 @@ async function allowNpmPublish(version) {
     const packageInfo = await execWithOutput('npm', ['view', '--json'])
     packageName = packageInfo ? JSON.parse(packageInfo).name : null
   } catch (error) {
-    console.log(error)
     if (!error?.message?.match(/code E404/)) {
       throw error
     }
@@ -80032,7 +80037,6 @@ async function allowNpmPublish(version) {
       `${packageName}@${version}`,
     ])
   } catch (error) {
-    console.log(error)
     if (!error?.message?.match(/code E404/)) {
       throw error
     }

--- a/src/utils/execWithOutput.js
+++ b/src/utils/execWithOutput.js
@@ -44,7 +44,13 @@ async function execWithOutput(cmd, args, { cwd } = {}) {
     },
   }
 
-  const code = await exec(cmd, args, options)
+  let code = 0
+  try {
+    code = await exec(cmd, args, options)
+  } catch {
+    //the actual error does not matter, because it does not contain any relevant information. The actual exec output is collected bellow in output and errorOutput
+    code = 1
+  }
 
   output += stdoutDecoder.end()
   errorOutput += stderrDecoder.end()

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -11,6 +11,7 @@ async function allowNpmPublish(version) {
     const packageInfo = await execWithOutput('npm', ['view', '--json'])
     packageName = packageInfo ? JSON.parse(packageInfo).name : null
   } catch (error) {
+    console.log(error)
     if (!error?.message?.match(/code E404/)) {
       throw error
     }
@@ -34,6 +35,7 @@ async function allowNpmPublish(version) {
       `${packageName}@${version}`,
     ])
   } catch (error) {
+    console.log(error)
     if (!error?.message?.match(/code E404/)) {
       throw error
     }

--- a/src/utils/publishToNpm.js
+++ b/src/utils/publishToNpm.js
@@ -11,7 +11,6 @@ async function allowNpmPublish(version) {
     const packageInfo = await execWithOutput('npm', ['view', '--json'])
     packageName = packageInfo ? JSON.parse(packageInfo).name : null
   } catch (error) {
-    console.log(error)
     if (!error?.message?.match(/code E404/)) {
       throw error
     }
@@ -35,7 +34,6 @@ async function allowNpmPublish(version) {
       `${packageName}@${version}`,
     ])
   } catch (error) {
-    console.log(error)
     if (!error?.message?.match(/code E404/)) {
       throw error
     }

--- a/test/execWithOutput.test.js
+++ b/test/execWithOutput.test.js
@@ -32,11 +32,29 @@ tap.test(
   }
 )
 
+tap.test(
+  'Throws with output of the exec command if exit code is not 0',
+  async t => {
+    const output = 'output'
+
+    execStub.callsFake((_, __, options) => {
+      options.listeners.stderr(Buffer.from(output, 'utf8'))
+      return Promise.reject(new Error())
+    })
+
+    t.rejects(
+      () => execWithOutputModule.execWithOutput('ls', ['-al']),
+      'Error: ls -al returned code 1  \nSTDOUT:  \nSTDERR: ${output}'
+    )
+
+    execStub.calledWith('ls', ['-al'])
+  }
+)
+
 tap.test('provides cwd to exec function', async () => {
   const cwd = './'
 
   execStub.resolves(0)
-
   execWithOutputModule.execWithOutput('command', [], cwd)
   execStub.calledWith('command', [], { cwd })
 })


### PR DESCRIPTION
Fixes: #248

The issue was that:
```javascript
const code = await exec(cmd, args, options)
```
Will throw an error if it fails to execute and the error will not contain the console output of the exec. I wrapped the bit into a try catch, so the underlying console output can be collected and put into the error message that is later handled by the outer function