### PR TITLE
Fix (issue 249): Remove double quotes from commits messages (when opening a PR)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79370,7 +79370,7 @@ module.exports = async function ({ context, inputs, packageVersion }) {
     'commit',
     '--no-verify',
     '-m',
-    `"${transformCommitMessage(messageTemplate, newVersion)}"`,
+    `${transformCommitMessage(messageTemplate, newVersion)}`,
   ])
 
   await execWithOutput('git', ['push', 'origin', branchName])

--- a/dist/index.js
+++ b/dist/index.js
@@ -79368,7 +79368,6 @@ module.exports = async function ({ context, inputs, packageVersion }) {
   await execWithOutput('git', ['add', '-A'])
   await execWithOutput('git', [
     'commit',
-    '--no-verify',
     '-m',
     `${transformCommitMessage(messageTemplate, newVersion)}`,
   ])

--- a/src/openPr.js
+++ b/src/openPr.js
@@ -101,7 +101,7 @@ module.exports = async function ({ context, inputs, packageVersion }) {
     'commit',
     '--no-verify',
     '-m',
-    `"${transformCommitMessage(messageTemplate, newVersion)}"`,
+    `${transformCommitMessage(messageTemplate, newVersion)}`,
   ])
 
   await execWithOutput('git', ['push', 'origin', branchName])

--- a/src/openPr.js
+++ b/src/openPr.js
@@ -99,7 +99,6 @@ module.exports = async function ({ context, inputs, packageVersion }) {
   await execWithOutput('git', ['add', '-A'])
   await execWithOutput('git', [
     'commit',
-    '--no-verify',
     '-m',
     `${transformCommitMessage(messageTemplate, newVersion)}`,
   ])

--- a/test/bump.test.js
+++ b/test/bump.test.js
@@ -129,7 +129,6 @@ tap.test('should create a new git branch', async () => {
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', ['add', '-A'])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'commit',
-    '--no-verify',
     '-m',
     `Release v${TEST_VERSION}`,
   ])
@@ -156,7 +155,6 @@ tap.test('should handle custom commit messages', async () => {
   ])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'commit',
-    '--no-verify',
     '-m',
     `[v${TEST_VERSION}] The brand new v${TEST_VERSION} has been released`,
   ])
@@ -191,7 +189,6 @@ tap.test('should work with a custom version-prefix', async () => {
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', ['add', '-A'])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'commit',
-    '--no-verify',
     '-m',
     `Release v${TEST_VERSION}`,
   ])

--- a/test/bump.test.js
+++ b/test/bump.test.js
@@ -131,7 +131,7 @@ tap.test('should create a new git branch', async () => {
     'commit',
     '--no-verify',
     '-m',
-    `"Release v${TEST_VERSION}"`,
+    `Release v${TEST_VERSION}`,
   ])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'push',
@@ -158,7 +158,7 @@ tap.test('should handle custom commit messages', async () => {
     'commit',
     '--no-verify',
     '-m',
-    `"[v${TEST_VERSION}] The brand new v${TEST_VERSION} has been released"`,
+    `[v${TEST_VERSION}] The brand new v${TEST_VERSION} has been released`,
   ])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'push',
@@ -193,7 +193,7 @@ tap.test('should work with a custom version-prefix', async () => {
     'commit',
     '--no-verify',
     '-m',
-    `"Release v${TEST_VERSION}"`,
+    `Release v${TEST_VERSION}`,
   ])
   sinon.assert.calledWithExactly(stubs.execWithOutputStub, 'git', [
     'push',


### PR DESCRIPTION
Fixes #249 

See playground for messages without `"` https://github.com/nearform/optic-release-automation-playground/commits/master

Fixes #250 

It seems the `"` were causing issues also for the conventional-changelog-commit