### PR TITLE
fix: quote npm pkg get version output for npm 12 (#649)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,10 @@ async function bumpVersion({ inputs }) {
     `--preid=${preReleasePrefix}`,
     newVersion,
   ])
-  return await execWithOutput('npm', ['pkg', 'get', 'version'])
+
+  const packageVersion = await execWithOutput('npm', ['pkg', 'get', 'version'])
+
+  return JSON.stringify(packageVersion.replace(/^"|"$/g, ''))
 }
 
 async function getAutoBumpedVersion(baseTag) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -160,7 +160,7 @@ describe('index tests', async () => {
       '--preid=',
       'major',
     ])
-    assert.strictEqual(newVersion, '3.0.0')
+    assert.strictEqual(newVersion, '"3.0.0"')
   })
 
   it('semver-auto: should not call getAutoBumpedVersion if semver is not auto', async () => {
@@ -175,8 +175,57 @@ describe('index tests', async () => {
 
     sinon.assert.notCalled(stubs.bumpStub)
     sinon.assert.calledTwice(stubs.execWithOutputStub)
-    assert.strictEqual(newVersion, '3.1.1')
+    assert.strictEqual(newVersion, '"3.1.1"')
   })
+
+  it('should return a quoted version literal when npm 12 omits the quotes (#649)', async () => {
+    const { bumpVersion, stubs } = buildStubbedAction()
+
+    // npm 12: `npm pkg get version` returns the version without quotes
+    stubs.execWithOutputStub.onCall(1).resolves('1.14.0')
+
+    const inputs = { semver: 'patch' }
+    const newVersion = await bumpVersion({
+      inputs,
+    })
+
+    // Must be a valid JS string literal for the action.yml github-script step
+    assert.strictEqual(newVersion, '"1.14.0"')
+  })
+
+  it('should return a quoted version literal when npm <12 includes the quotes (#649)', async () => {
+    const { bumpVersion, stubs } = buildStubbedAction()
+
+    // npm <12: `npm pkg get version` returns the version already quoted
+    stubs.execWithOutputStub.onCall(1).resolves('"1.14.0"')
+
+    const inputs = { semver: 'patch' }
+    const newVersion = await bumpVersion({
+      inputs,
+    })
+
+    assert.strictEqual(newVersion, '"1.14.0"')
+  })
+
+  for (const { npmOutput, expected } of [
+    { npmOutput: '"1.14.0"', expected: '1.14.0' }, // npm <12, quoted
+    { npmOutput: '1.14.0', expected: '1.14.0' }, // npm 12, unquoted
+    { npmOutput: '"2.0.0-rc.1"', expected: '2.0.0-rc.1' }, // prerelease, quoted
+    { npmOutput: '2.0.0-rc.1', expected: '2.0.0-rc.1' }, // prerelease, unquoted
+  ]) {
+    it(`should produce a valid JS literal for npm output ${npmOutput} (#649)`, async () => {
+      const { bumpVersion, stubs } = buildStubbedAction()
+
+      stubs.execWithOutputStub.onCall(1).resolves(npmOutput)
+
+      const newVersion = await bumpVersion({ inputs: { semver: 'patch' } })
+
+      // Parsing as JS source must not throw (the #649 SyntaxError), and the
+      // literal must evaluate back to the clean version string.
+      const evaluated = new Function(`return ${newVersion}`)()
+      assert.strictEqual(evaluated, expected)
+    })
+  }
 
   it('semver-auto: should bump major if breaking change', async () => {
     const { bumpVersion, stubs } = buildStubbedAction()
@@ -197,7 +246,7 @@ describe('index tests', async () => {
       '--preid=',
       'major',
     ])
-    assert.strictEqual(newVersion, '3.0.0')
+    assert.strictEqual(newVersion, '"3.0.0"')
   })
 
   it('semver-auto: should bump minor if its a feat', async () => {
@@ -219,7 +268,7 @@ describe('index tests', async () => {
       '--preid=',
       'minor',
     ])
-    assert.strictEqual(newVersion, '3.0.0')
+    assert.strictEqual(newVersion, '"3.0.0"')
   })
 
   it('semver-auto: should bump patch if its a fix', async () => {
@@ -241,7 +290,7 @@ describe('index tests', async () => {
       '--preid=',
       'patch',
     ])
-    assert.strictEqual(newVersion, '3.0.0')
+    assert.strictEqual(newVersion, '"3.0.0"')
   })
 
   it('semver-auto: should use the correct base tag if specified', async () => {
@@ -267,7 +316,7 @@ describe('index tests', async () => {
       '--preid=',
       'patch',
     ])
-    assert.strictEqual(newVersion, '3.0.0')
+    assert.strictEqual(newVersion, '"3.0.0"')
   })
 
   it('semver-auto: should get the latest tag if base tag not provided', async () => {
@@ -294,7 +343,7 @@ describe('index tests', async () => {
       '--preid=',
       'patch',
     ])
-    assert.strictEqual(newVersion, '3.0.0')
+    assert.strictEqual(newVersion, '"3.0.0"')
   })
 
   it('semver-auto: should throw if auto bump fails', async () => {
@@ -338,6 +387,6 @@ describe('index tests', async () => {
       '--preid=',
       'patch',
     ])
-    assert.deepStrictEqual(newVersion, '3.0.0')
+    assert.deepStrictEqual(newVersion, '"3.0.0"')
   })
 })


### PR DESCRIPTION
## What

Fixes the release automation breaking under **npm 12**, which throws
`SyntaxError: Unexpected number` during the version-bump step.
Fixes #649

## Why

`bumpVersion()` returns the raw output of `npm pkg get version`. That value is
stored as a step output (`result-encoding: string`) and then interpolated
**verbatim into JavaScript source** in the `github-script` step in `action.yml`:

```yaml
packageVersion: ${{ steps.version-bump.outputs.result || steps.custom-get-version.outputs.version }}
```

So the returned value must be a valid JS string literal.

- npm ≤ 11: `npm pkg get version` → `"1.14.0"` (quoted) → `packageVersion: "1.14.0"` ✅
- npm 12: `npm pkg get version` → `1.14.0` (unquoted) → `packageVersion: 1.14.0` → **`SyntaxError: Unexpected number`** ❌

The `custom-get-version` branch was never affected because it already quotes the
value via the shell, which is why the fix belongs on the `bumpVersion` path.

## How

Normalize the npm output — strip any surrounding quotes and re-quote via
`JSON.stringify` — so `bumpVersion` always returns a valid, properly-escaped JS
string literal regardless of npm version:

```js
const packageVersion = await execWithOutput('npm', ['pkg', 'get', 'version'])
return JSON.stringify(packageVersion.replace(/^"|"$/g, ''))
```

`JSON.stringify` also escapes the value, which hardens the `github-script`
interpolation against unexpected characters (e.g. via the user-controlled
`prerelease-prefix` input).

## Testing

- Added two tests covering both npm behaviors (quoted npm ≤11 output and
  unquoted npm 12 output), both asserting a valid quoted literal is returned.
- Updated existing `bumpVersion` assertions to reflect the quoted return value.
- Full suite green: **173/173 passing**, 100% coverage maintained; lint clean.
- Rebuilt `dist/index.js` (the bundle the action actually runs).
